### PR TITLE
Resets the order back to the entry state

### DIFF
--- a/SourcesF/diff_mod.f90
+++ b/SourcesF/diff_mod.f90
@@ -90,12 +90,15 @@ contains
     complex(prec), intent(in), dimension(:) :: v, q
     complex(prec) :: fr
     type(dualzn) :: eps1
+    integer :: order
 
-    call set_order(2)   
+    order = get_order()
+    call set_order(2)
     eps1 = 0
     eps1%f(1) = 1
 
-    fr = f_part(fsd(q + eps1*v),2)   
+    fr = f_part(fsd(q + eps1*v),2)
+    call set_order(order)
   end function d2fscalarvv
 
   !Jacobian operator: To optimize efficiency, we include the parameter
@@ -129,12 +132,15 @@ contains
     integer, intent(in) :: n
     complex(prec), dimension(n) :: fr  
     type(dualzn) :: eps1
+    integer :: order
 
+    order = get_order()
     call set_order(1)
     eps1 = 0
     eps1%f(1) = 1
 
     fr = f_part(fvecd(q + eps1*v),1)
+    call set_order(order)
   end function d1fvector
 
   function gradient(fsd,q) result(fr)
@@ -158,11 +164,14 @@ contains
     complex(prec), intent(in), dimension(:) :: v, q
     complex(prec) :: fr  
     type(dualzn) :: eps1
+    integer :: order
 
+    order = get_order()
     call set_order(1)
     eps1 = 0
     eps1%f(1) = 1
 
     fr = f_part(fsd(q + eps1*v),1)
+    call set_order(order)
   end function d1fscalar
 end module diff_mod

--- a/SourcesF/dualzn_mod.f90
+++ b/SourcesF/dualzn_mod.f90
@@ -22,7 +22,7 @@ module dualzn_mod
      complex(prec), allocatable, dimension(:) :: f
   end type dualzn
 
-  public :: set_order, initialize_dualzn, f_part
+  public :: set_order, get_order, initialize_dualzn, f_part
   public :: binomial, BellY, Dnd
   public :: itodn, realtodn, cmplxtodn, Mset_fpart
 
@@ -230,6 +230,12 @@ contains
     end if
     order = new_order
   end subroutine set_order
+
+  !check the order for dual numbers
+  pure function get_order()
+    integer :: get_order
+    get_order = order
+  end function get_order
   !---------------------------------------------------------------------
 
   !Assignment, equal operator


### PR DESCRIPTION
Several routines locally set order (for efficiency or safety of what they are calculating), but left the order at the changed value.

This change introduces a get_order function and resets the order back the entry value on exit for the affected routines.