### PR TITLE
Set order module variable as protected

### DIFF
--- a/SourcesF/diff_mod.f90
+++ b/SourcesF/diff_mod.f90
@@ -90,15 +90,15 @@ contains
     complex(prec), intent(in), dimension(:) :: v, q
     complex(prec) :: fr
     type(dualzn) :: eps1
-    integer :: order
+    integer :: original_order
 
-    order = get_order()
+    original_order = get_order()
     call set_order(2)
     eps1 = 0
     eps1%f(1) = 1
 
     fr = f_part(fsd(q + eps1*v),2)
-    call set_order(order)
+    call set_order(original_order)
   end function d2fscalarvv
 
   !Jacobian operator: To optimize efficiency, we include the parameter
@@ -132,15 +132,15 @@ contains
     integer, intent(in) :: n
     complex(prec), dimension(n) :: fr  
     type(dualzn) :: eps1
-    integer :: order
+    integer :: original_order
 
-    order = get_order()
+    original_order = get_order()
     call set_order(1)
     eps1 = 0
     eps1%f(1) = 1
 
     fr = f_part(fvecd(q + eps1*v),1)
-    call set_order(order)
+    call set_order(original_order)
   end function d1fvector
 
   function gradient(fsd,q) result(fr)
@@ -164,14 +164,14 @@ contains
     complex(prec), intent(in), dimension(:) :: v, q
     complex(prec) :: fr  
     type(dualzn) :: eps1
-    integer :: order
+    integer :: original_order
 
-    order = get_order()
+    original_order = get_order()
     call set_order(1)
     eps1 = 0
     eps1%f(1) = 1
 
     fr = f_part(fsd(q + eps1*v),1)
-    call set_order(order)
+    call set_order(original_order)
   end function d1fscalar
 end module diff_mod

--- a/SourcesF/dualzn_mod.f90
+++ b/SourcesF/dualzn_mod.f90
@@ -13,7 +13,7 @@ module dualzn_mod
   !---------------------------------------------------------------------
   !Some Module variables
   !Default order, can be modified with set_order
-  integer, public  :: order = 1
+  integer, protected :: order = 1
   real(prec), public, parameter :: Pi = 4.0_prec*atan(1.0_prec)
   !---------------------------------------------------------------------
 

--- a/SourcesF_gfortran/diff_mod.f90
+++ b/SourcesF_gfortran/diff_mod.f90
@@ -90,12 +90,15 @@ contains
     complex(prec), intent(in), dimension(:) :: v, q
     complex(prec) :: fr
     type(dualzn) :: eps1
+    integer :: original_order
 
-    call set_order(2)   
+    original_order = get_order()
+    call set_order(2)
     eps1 = 0
     eps1%f(1) = 1
 
-    fr = f_part(fsd(add_vecdzn(cmplxtodn(q),eps1*v)),2)  
+    fr = f_part(fsd(add_vecdzn(cmplxtodn(q),eps1*v)),2)
+    call set_order(original_order)
   end function d2fscalarvv
 
   !Jacobian operator: To optimize efficiency, we include the parameter
@@ -131,7 +134,9 @@ contains
     type(dualzn) :: eps1
     type(dualzn), allocatable, dimension(:) ::  auxv
     integer :: k
+    integer :: original_order
 
+    original_order = get_order()
     call set_order(1)
     eps1 = 0
     eps1%f(1) = 1
@@ -144,6 +149,7 @@ contains
       deallocate(auxv(k)%f)
     end do 
     deallocate(auxv)
+    call set_order(original_order)
   end function d1fvector
 
   function gradient(fsd,q) result(fr)
@@ -167,12 +173,15 @@ contains
     complex(prec), intent(in), dimension(:) :: v, q
     complex(prec) :: fr  
     type(dualzn) :: eps1
+    integer :: original_order
 
+    original_order = get_order()
     call set_order(1)
     eps1 = 0
     eps1%f(1) = 1
 
-    fr = f_part(fsd(add_vecdzn(cmplxtodn(q),eps1*v)),1)  
+    fr = f_part(fsd(add_vecdzn(cmplxtodn(q),eps1*v)),1)
+    call set_order(original_order)
   end function d1fscalar
 
   function add_vecdzn(x,y) result(fr)

--- a/SourcesF_gfortran/dualzn_mod.f90
+++ b/SourcesF_gfortran/dualzn_mod.f90
@@ -13,7 +13,7 @@ module dualzn_mod
   !---------------------------------------------------------------------
   !Some Module variables
   !Default order, can be modified with set_order
-  integer, public  :: order = 1
+  integer, protected :: order = 1
   real(prec), public, parameter :: Pi = 4.0_prec*atan(1.0_prec)
   !---------------------------------------------------------------------
 
@@ -22,7 +22,7 @@ module dualzn_mod
      complex(prec), allocatable, dimension(:) :: f
   end type dualzn
 
-  public :: set_order, initialize_dualzn, f_part
+  public :: set_order, get_order, initialize_dualzn, f_part
   public :: binomial, BellY, Dnd
   public :: itodn, realtodn, cmplxtodn, Mset_fpart
 
@@ -230,6 +230,12 @@ contains
     end if
     order = new_order
   end subroutine set_order
+
+  !check the order for dual numbers
+  pure function get_order() result(order_value)
+    integer :: order_value
+    order_value = order
+  end function get_order
   !---------------------------------------------------------------------
 
   !Assignment, equal operator


### PR DESCRIPTION
Rename order to original_order in diff_mod to avoid colision with module variable name in dualzn_mod.
Also update gfortran directory for dualzn change to get_order().
closes #14 